### PR TITLE
Quick css fix

### DIFF
--- a/jeff_control/www/commands.html
+++ b/jeff_control/www/commands.html
@@ -31,9 +31,9 @@
 		<div id="controls_inner">
 
 		<div id="control_tabs">
-			<div id="functions_tab" class="tab" onclick="activate_tab(this.id)">Functions</div>
-			<div id="constants_tab" class="tab" onclick="activate_tab(this.id)">Constants</div>
-			<div id="loops_tab" class="tab" onclick="activate_tab(this.id)">Loops</div>
+			<div id="functions_tab" class="tab_active" onclick="activate_tab(this.id)">Functions</div>
+			<div id="constants_tab" class="tab_inactive" onclick="activate_tab(this.id)">Constants</div>
+			<div id="loops_tab" class="tab_inactive" onclick="activate_tab(this.id)">Loops</div>
 		</div>
 
 			<!-- Controls Tab -->

--- a/jeff_control/www/js/command_script.js
+++ b/jeff_control/www/js/command_script.js
@@ -119,31 +119,31 @@ function activate_tab(tab) {
 	if (tab == 'functions_tab') {
 
 		$('#control_constants').css('display', 'none');
-		$('#constants_tab').css('background', '#106060');
+		document.getElementById('constants_tab').className = "tab_inactive";
 		$('#control_loops').css('display', 'none');
-		$('#loops_tab').css('background', '#106060');
+		document.getElementById('loops_tab').className = "tab_inactive";
 		$('#control_functions').css('display', 'initial');
-		$('#functions_tab').css('background', '#339999');
+		document.getElementById('functions_tab').className = "tab_active";
 
 	// Activates tab for constants.
 	} else if (tab == 'constants_tab') {
 
 		$('#control_constants').css('display', 'initial');
-		$('#constants_tab').css('background', '#339999');
+		document.getElementById('constants_tab').className = "tab_active";
 		$('#control_loops').css('display', 'none');
-		$('#loops_tab').css('background', '#106060');
+		document.getElementById('loops_tab').className = "tab_inactive";
 		$('#control_functions').css('display', 'none');
-		$('#functions_tab').css('background', '#106060');
+		document.getElementById('functions_tab').className = "tab_inactive";
 
 	// Activates tab for loops.
 	} else if (tab == 'loops_tab') {
 
 		$('#control_constants').css('display', 'none');
-		$('#constants_tab').css('background', '#106060');
+		document.getElementById('constants_tab').className = "tab_inactive";
 		$('#control_loops').css('display', 'initial');
-		$('#loops_tab').css('background', '#339999');
+		document.getElementById('loops_tab').className = "tab_active";
 		$('#control_functions').css('display', 'none');
-		$('#functions_tab').css('background', '#106060');
+		document.getElementById('functions_tab').className = "tab_inactive";
 
 	}
 

--- a/jeff_control/www/styles/commands.css
+++ b/jeff_control/www/styles/commands.css
@@ -90,11 +90,23 @@
 	height: 2em;
 }
 
-.tab {
+.tab_active, .tab_inactive {
 	text-align: center;
 	padding-top: 0.4em;
 	height: 100%;
+}
+
+.tab_active {
+	background: #339999;
+}
+
+.tab_inactive {
 	background: #106060;
+}
+
+.tab_inactive:hover {
+	background: #208080;
+	cursor: pointer;
 }
 
 /* loops_tab excluded and will auto-fill remaining area.
@@ -103,15 +115,6 @@
 #functions_tab, #constants_tab {
 	float: left;
 	width: 33.3%;
-}
-
-#functions_tab {
-	background: #339999;
-}
-
-.tab:hover {
-	background: #339999;
-	cursor: pointer;
 }
 
 .control_type {


### PR DESCRIPTION
Tabs used javascript for direct changes to css properties. Not ideal, and breaks the on-hover by overwriting. Fixed.